### PR TITLE
Create android.yml for build testing

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,26 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: cd USBMidiAndroid && ./gradlew build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,4 +23,4 @@ jobs:
     - name: Grant execute permission for gradlew
       run: cd USBMidiAndroid && chmod +x gradlew
     - name: Build with Gradle
-      run: cd USBMidiAndroid && ./gradlew build
+      run: cd USBMidiAndroid && ./gradlew build --scan

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,6 +21,6 @@ jobs:
         cache: gradle
 
     - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+      run: cd USBMidiAndroid && chmod +x gradlew
     - name: Build with Gradle
       run: cd USBMidiAndroid && ./gradlew build

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -11,6 +11,8 @@ on:
   release:
     types: [created]
 
+  workflow_dispatch:
+
 jobs:
   build:
 

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,0 +1,45 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a package using Gradle and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-gradle
+
+name: Gradle Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Build with Gradle
+      uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+      with:
+        arguments: build
+
+    # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
+    # the publishing section of your build.gradle
+    - name: Publish to GitHub Packages
+      uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+      with:
+        arguments: publish
+      env:
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.JAVA_TOKEN }}

--- a/USBMidiAndroid/build.gradle
+++ b/USBMidiAndroid/build.gradle
@@ -12,6 +12,19 @@ buildscript {
     }
 }
 
+publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/ArthurVasseur/USB-Midi-Android-Plugin")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/USBMidiAndroid/build.gradle
+++ b/USBMidiAndroid/build.gradle
@@ -25,6 +25,11 @@ publishing {
     }
 }
 
+buildScan {
+    termsOfServiceUrl = "https://gradle.com/terms-of-service"
+    termsOfServiceAgree = "yes"
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/USBMidiAndroid/build.gradle
+++ b/USBMidiAndroid/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'maven-publish'
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {


### PR DESCRIPTION
This merge request adds an android.yml file for configuring the Android CI pipeline in GitHub Actions. The pipeline is triggered on pushes and pull requests to the main branch.