### PR TITLE
Fixes to threading, callbacks, receivers, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ Then implements all the methods of `IMidiEventHandler` :
 
 ```csharp
 [SerializeField] private Text text;
+// Called for all midi commands, to receive raw midi data, including before NoteOn and NoteOff
+public void RawMidi(sbyte command, sbyte data1, sbyte data2)
+{
+    string output = string.Format("MIDI command: {0:x2} {1:x2} {2:x2}", command, data1, data2);
+    Debug.Log(output);
+    text.text += output + Environment.NewLine;
+}
+   
 // Called when you plug a midi note is down
 public void NoteOn(int note, int velocity)
 {

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ public class MyCallback implements IMidiCallback {
     {
         _textView = textView;
     }
+
+    @Override
+    public void RawMidi(byte command, byte data1, byte data2) {
+        _textView.append(" MIDI command : " + command + ", " + data1 + ", " + data2 + System.lineSeparator());
+    }
+
     @Override
     public void NoteOn(int note, int velocity) {
         _textView.append(" Note : " + note + " velocity : " + velocity + System.lineSeparator());

--- a/USBMidiAndroid/src/main/java/com/arthaiirgames/usbmidiandroid/IMidiCallback.java
+++ b/USBMidiAndroid/src/main/java/com/arthaiirgames/usbmidiandroid/IMidiCallback.java
@@ -1,8 +1,9 @@
 package com.arthaiirgames.usbmidiandroid;
 
 public interface IMidiCallback {
-    void NoteOn(int note, int velocity);
-    void NoteOff(int note);
     void DeviceAttached(String name);
     void DeviceDetached(String name);
+    void RawMidi(byte command, byte data1, byte data2);
+    void NoteOn(int note, int velocity);
+    void NoteOff(int note);
 }

--- a/USBMidiAndroid/src/main/java/com/arthaiirgames/usbmidiandroid/UsbMidiController.java
+++ b/USBMidiAndroid/src/main/java/com/arthaiirgames/usbmidiandroid/UsbMidiController.java
@@ -35,7 +35,8 @@ public class UsbMidiController {
     private Context _context;
     private final String USB_PERMISSION_ACTION = "com.arthaiirgames.unitymidiandroid.USB_PERMISSION_GRANTED_ACTION";
     private IMidiCallback _midiCallback = null;
-    private ArrayList<MidiInputDevice> _interfaces = null;
+    private UsbReceiver _receiver = null;
+    private HashMap<UsbDevice, ArrayList<MidiInputDevice>> _interfacesByUsbDevice = new HashMap<>();
 
     private UsbMidiController() {
     }
@@ -43,34 +44,56 @@ public class UsbMidiController {
     public void ctor(IMidiCallback callback, @NonNull Activity activity) {
         _context = activity.getApplicationContext();
         _midiCallback = callback;
-        registerMidiDevices();
+        _receiver = new UsbReceiver();
+        registerUsbReceiver();
+        discoverExistingDevices();
     }
 
-    public void registerMidiDevices() {
+    private void registerUsbReceiver() {
         _usbManager = (UsbManager) _context.getSystemService(Context.USB_SERVICE);
+        try {
+            PendingIntent permissionIntent = createUsbPermissionIntent();
+            IntentFilter filter = new IntentFilter(USB_PERMISSION_ACTION);
+            filter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
+            filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
+            UsbReceiver receiver = new UsbReceiver();
+            _context.registerReceiver(receiver, filter);
+        } catch (Exception e) {
+            String message = e.getMessage();
+            if (message == null)
+                Log.e("UsbMidiController", e.toString());
+            else Log.e("UsbMidiController", e.getMessage());
+        }
+    }
+
+    // Receiver will detect new devices added but on start-up we must handle existing devices
+    private void discoverExistingDevices() {
         HashMap<String, UsbDevice> map = _usbManager.getDeviceList();
         for (UsbDevice usbDevice : map.values()) {
-            try {
-                int flag;
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    flag = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE;
-
-                } else {
-                    flag = PendingIntent.FLAG_UPDATE_CURRENT;
-                }
-                PendingIntent permissionIntent = PendingIntent.getBroadcast(_context, 0, new Intent(USB_PERMISSION_ACTION), flag);
-                IntentFilter filter = new IntentFilter(USB_PERMISSION_ACTION);
-                filter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
-                filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
-                _context.registerReceiver(new UsbReceiver(usbDevice), filter);
-                _usbManager.requestPermission(usbDevice, permissionIntent);
-            } catch (Exception e) {
-                String message = e.getMessage();
-                if (message == null)
-                    Log.e("UsbMidiController", e.toString());
-                else Log.e("UsbMidiController", e.getMessage());
-            }
+            requestPermissionForDevice(usbDevice);
         }
+    }
+
+    private void requestPermissionForDevice(UsbDevice usbDevice) {
+        try {
+            PendingIntent permissionIntent = createUsbPermissionIntent();
+            _usbManager.requestPermission(usbDevice, permissionIntent);
+        } catch (Exception e) {
+            String message = e.getMessage();
+            if (message == null)
+                Log.e("UsbMidiController", e.toString());
+            else Log.e("UsbMidiController", e.getMessage());
+        }
+    }
+
+    private PendingIntent createUsbPermissionIntent() {
+        int flag;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            flag = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE;
+        } else {
+            flag = PendingIntent.FLAG_UPDATE_CURRENT;
+        }
+        return PendingIntent.getBroadcast(_context, 0, new Intent(USB_PERMISSION_ACTION), flag);
     }
 
     @Nullable
@@ -103,27 +126,43 @@ public class UsbMidiController {
         return null;
     }
 
-    private class UsbReceiver extends BroadcastReceiver {
-        private final UsbDevice _usbDevice;
+    private void addMidiInputDevices(UsbDevice device, ArrayList<MidiInputDevice> interfaces) {
+        _interfacesByUsbDevice.put(device, interfaces);
+    }
 
-        public UsbReceiver(UsbDevice usbDevice) {
-            _usbDevice = usbDevice;
+    private void removeMidiInputDevices(UsbDevice device) {
+        ArrayList<MidiInputDevice> interfaces = _interfacesByUsbDevice.remove(device);
+        if (interfaces != null)
+        {
+            for (int i = 0; i < interfaces.size(); i++) {
+                interfaces.get(i).stopThread();
+            }
         }
+    }
 
+    private class UsbReceiver extends BroadcastReceiver {
         @Override
         public void onReceive(Context context, Intent intent) {
+            UsbDevice usbDevice = (UsbDevice)intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
             String action = intent.getAction();
             if (intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)) {
                 if (USB_PERMISSION_ACTION.equals(action)) {
-                    _interfaces = getAllMidiInterfaces(_usbDevice);
+                    // Get MIDI interfaces (if any)
+                    ArrayList<MidiInputDevice> interfaces = getAllMidiInterfaces(usbDevice);
+                    if (interfaces.size() > 0)
+                    {
+                        removeMidiInputDevices(usbDevice);
+                        addMidiInputDevices(usbDevice, interfaces);
+                        _midiCallback.DeviceAttached(usbDevice.getDeviceName());
+                    }
                 }
             }
             if (UsbManager.ACTION_USB_DEVICE_DETACHED.equals(action)) {
-                _midiCallback.DeviceDetached(_usbDevice.getDeviceName());
+                removeMidiInputDevices(usbDevice);
+                _midiCallback.DeviceDetached(usbDevice.getDeviceName());
             }
             if (UsbManager.ACTION_USB_DEVICE_ATTACHED.equals(action)) {
-                _midiCallback.DeviceAttached(_usbDevice.getDeviceName());
-                registerMidiDevices();
+                requestPermissionForDevice(usbDevice);
             }
         }
     }

--- a/USBMidiAndroid/src/main/java/com/arthaiirgames/usbmidiandroid/UsbMidiController.java
+++ b/USBMidiAndroid/src/main/java/com/arthaiirgames/usbmidiandroid/UsbMidiController.java
@@ -35,7 +35,6 @@ public class UsbMidiController {
     private Context _context;
     private final String USB_PERMISSION_ACTION = "com.arthaiirgames.unitymidiandroid.USB_PERMISSION_GRANTED_ACTION";
     private IMidiCallback _midiCallback = null;
-    private UsbReceiver _receiver = null;
     private HashMap<UsbDevice, ArrayList<MidiInputDevice>> _interfacesByUsbDevice = new HashMap<>();
 
     private UsbMidiController() {
@@ -44,7 +43,6 @@ public class UsbMidiController {
     public void ctor(IMidiCallback callback, @NonNull Activity activity) {
         _context = activity.getApplicationContext();
         _midiCallback = callback;
-        _receiver = new UsbReceiver();
         registerUsbReceiver();
         discoverExistingDevices();
     }

--- a/exampleandroidapplication/src/main/java/com/arthaiirgames/exampleandroidapplication/MyCallback.java
+++ b/exampleandroidapplication/src/main/java/com/arthaiirgames/exampleandroidapplication/MyCallback.java
@@ -12,6 +12,12 @@ public class MyCallback implements IMidiCallback {
     {
         _textView = textView;
     }
+
+    @Override
+    public void RawMidi(byte command, byte data1, byte data2) {
+        _textView.append(" MIDI command : " + command + ", " + data1 + ", " + data2 + System.lineSeparator());
+    }
+
     @Override
     public void NoteOn(int note, int velocity) {
         _textView.append(" Note : " + note + " velocity : " + velocity + System.lineSeparator());


### PR DESCRIPTION
- Only a single BroadcastReceiver for USB events is now created. Previously, a new one was being created each time a USB device was attached (even if it was the same device being re-attached), causing an additional redundant onReceive() call each time a MIDI device was disconnected and then reconnected.
- On device detachment, USB reader threads are stopped (although we do not actually join() them; seems to work ok for now).
- The DeviceAttached callback will now fire if the device is already plugged in.
- Added a RawMidi callback that fires on any MIDI data received and always before NoteOn/NoteOff.